### PR TITLE
fix: [@heimdallr-sdk/browser] log is not a function

### DIFF
--- a/packages/browser/src/plugins/lifeCycle.ts
+++ b/packages/browser/src/plugins/lifeCycle.ts
@@ -54,14 +54,14 @@ function lifeCyclePlugin(options: LifecycleOptions = {}): BasePluginType {
         notify({
           lt: PageLifeType.LOAD,
           href: location.href,
-          ...getIds(userIdentify)
+          ...getIds.call(this, userIdentify)
         });
       });
       window.addEventListener('unload', () => {
         notify({
           lt: PageLifeType.UNLOAD,
           href: location.href,
-          ...getIds(userIdentify)
+          ...getIds.call(this, userIdentify)
         });
       });
     },


### PR DESCRIPTION
修复`lifeCyclePlugin`插件中`getId`函数有用到`Core`里面的`log`方法，使用时没有绑定`this`导致读取不到`log`方法